### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol (MCP) server implementation that provides deployed CrewAI workflows. This server enables kicking off your deployed crew and inspect the status giving the results of your crew.
 
+<a href="https://glama.ai/mcp/servers/@crewAIInc/enterprise-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@crewAIInc/enterprise-mcp-server/badge" alt="CrewAI Enterprise Server MCP server" />
+</a>
+
 ## Tools
 
 - kickoff_crew


### PR DESCRIPTION
This PR adds a badge for the [CrewAI Enterprise MCP Server](https://glama.ai/mcp/servers/@crewAIInc/enterprise-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@crewAIInc/enterprise-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@crewAIInc/enterprise-mcp-server/badge" alt="CrewAI Enterprise Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.